### PR TITLE
unify test syntax and reorder some models

### DIFF
--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -40,14 +40,14 @@
 class Admin < ApplicationRecord
   include AdminRailsAdmin
 
+  mount_uploader :avatar, AvatarUploader
+
   has_many :work_experiences, dependent: :destroy
   has_many :skills, dependent: :destroy
   has_many :recommendations, dependent: :destroy
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
-
-  mount_uploader :avatar, AvatarUploader
 
   validates :first_name,
             :last_name,

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -27,13 +27,15 @@
 class Article < ApplicationRecord
   scope :latest, -> { order(published_at: :desc).first(4) }
 
-  validates :title, presence: true
-  validates :summary, presence: true
-  validates :page_header, presence: true
-  validates :slug, presence: true, uniqueness: true
-
   has_many :comments, dependent: :destroy
+
   belongs_to :category
+
+  validates :title,
+            :summary,
+            :page_header,
+            :slug, presence: true
+  validates :slug, uniqueness: true
 
   before_create :assign_slug
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -17,8 +17,8 @@
 class Comment < ApplicationRecord
   belongs_to :article
 
-  validates :name, presence: true
-  validates :email, presence: true
-  validates :message, presence: true
-  validates :article, presence: true
+  validates :name,
+            :email,
+            :message,
+            :article, presence: true
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -44,21 +44,23 @@ describe Article do
 
   describe 'callbacks' do
     describe 'before_create' do
-      context 'when title is not present' do
-        let(:article) { build :article, title: nil }
+      describe '#assign_slug' do
+        context 'when title is not present' do
+          let(:article) { build :article, title: nil }
 
-        it 'does not raise an error' do
-          expect { article.send(:assign_slug) }.not_to raise_error
+          it 'does not raise an error' do
+            expect { article.send(:assign_slug) }.not_to raise_error
+          end
         end
-      end
 
-      context 'when title is present' do
-        let(:article) { build :article, title: 'My New Article' }
+        context 'when title is present' do
+          let(:article) { build :article, title: 'My New Article' }
 
-        it 'assigns the corresponding slug' do
-          article.send(:assign_slug)
+          it 'assigns the corresponding slug' do
+            article.send(:assign_slug)
 
-          expect(article.slug).to eq 'my-new-article'
+            expect(article.slug).to eq 'my-new-article'
+          end
         end
       end
     end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -19,9 +19,13 @@
 require 'rails_helper'
 
 describe Message do
+  describe 'associations' do
+    it { is_expected.to belong_to :admin }
+  end
+
   describe 'validations' do
-    it { should validate_presence_of(:name) }
-    it { should validate_presence_of(:email) }
-    it { should validate_presence_of(:message) }
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.to validate_presence_of(:message) }
   end
 end

--- a/spec/models/recommendation_spec.rb
+++ b/spec/models/recommendation_spec.rb
@@ -23,6 +23,10 @@
 require 'rails_helper'
 
 describe Recommendation do
+  describe 'associations' do
+    it { is_expected.to belong_to :admin }
+  end
+
   describe 'validations' do
     subject { build :recommendation }
     it { is_expected.to validate_presence_of :admin }
@@ -30,9 +34,5 @@ describe Recommendation do
 
   describe 'enums' do
     it { is_expected.to define_enum_for(:relationship) }
-  end
-
-  describe 'associations' do
-    it { is_expected.to belong_to :admin }
   end
 end

--- a/spec/models/skill_spec.rb
+++ b/spec/models/skill_spec.rb
@@ -18,12 +18,12 @@ require 'rails_helper'
 
 describe Skill do
   describe 'associations' do
-    it { should belong_to :admin }
+    it { is_expected.to belong_to :admin }
   end
 
   describe 'validations' do
-    it { should validate_presence_of :name }
-    it { should validate_presence_of :percentage }
-    it { should validate_presence_of :admin }
+    it { is_expected.to validate_presence_of :name }
+    it { is_expected.to validate_presence_of :percentage }
+    it { is_expected.to validate_presence_of :admin }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -35,22 +35,13 @@ require 'rails_helper'
 describe User do
   describe 'validations' do
     subject { build :user }
-    it { should validate_uniqueness_of(:uid).scoped_to(:provider) }
+    it { is_expected.to validate_uniqueness_of(:uid).scoped_to(:provider) }
 
     context 'when was created with regular login' do
       subject { build :user }
       # Pending test until https://github.com/lynndylanhurley/devise_token_auth/pull/865 is merged
-      xit { should validate_uniqueness_of(:email).case_insensitive.scoped_to(:provider) }
-      it { should validate_presence_of(:email) }
-    end
-  end
-
-  context 'when was created with regular login' do
-    let!(:user) { create(:user) }
-    let(:full_name) { user.full_name }
-
-    it 'returns the correct name' do
-      expect(full_name).to eq(user.username)
+      xit { is_expected.to validate_uniqueness_of(:email).case_insensitive.scoped_to(:provider) }
+      it { is_expected.to validate_presence_of(:email) }
     end
   end
 end

--- a/spec/models/work_experience_spec.rb
+++ b/spec/models/work_experience_spec.rb
@@ -22,14 +22,14 @@ require 'rails_helper'
 describe WorkExperience do
   describe 'validations' do
     subject { build :work_experience }
-    it { should validate_presence_of :start_at }
-    it { should validate_presence_of :company }
-    it { should validate_presence_of :position }
-    it { should validate_presence_of :description }
-    it { should validate_presence_of :admin }
+    it { is_expected.to validate_presence_of :start_at }
+    it { is_expected.to validate_presence_of :company }
+    it { is_expected.to validate_presence_of :position }
+    it { is_expected.to validate_presence_of :description }
+    it { is_expected.to validate_presence_of :admin }
   end
 
   describe 'Associations' do
-    it { should belong_to :admin }
+    it { is_expected.to belong_to :admin }
   end
 end


### PR DESCRIPTION
## Unify test syntax and reorder some models
#### Trello board reference:

* [Trello Card #NONE]()

---

#### Description:

* This PR unify the test syntax, to use `expect` instead of `should` and also reorder some models. It also adds some missed tests.
---

#### Reviewers:

* @GAKINDUSTRIES

---

#### Notes:

*

---

#### Tasks:

  - [x] Reorder models
  - [x] Change test syntax to use `expect` instead of `should`
  - [x] Add missed test for message model.

---

#### Risk:

 Options: (None, little, Medium, Risky)

* Medium

---


#### Preview:



---
